### PR TITLE
add working video concept

### DIFF
--- a/app/concepts/video/cell/video.rb
+++ b/app/concepts/video/cell/video.rb
@@ -1,0 +1,5 @@
+module Video::Cell
+  class Video < Component::Cell::Static
+
+  end
+end

--- a/app/concepts/video/view/video.haml
+++ b/app/concepts/video/view/video.haml
@@ -1,0 +1,1 @@
+= video_tag(ActionController::Base.helpers.asset_path(options[:path]), height: options[:height], width: options[:width], preload: options[:preload], class: options[:class], id: options[:id], controls: options[:controls] )


### PR DESCRIPTION
There seems to be an issue about where Rails Asset pipeline looks for videos (assets/image vs. public/videos), but this works for me, locally.