### PR TITLE
Allow actions to accept id and class attributes

### DIFF
--- a/app/concepts/action/view/action.haml
+++ b/app/concepts/action/view/action.haml
@@ -1,3 +1,3 @@
-%a{"@click.prevent": "perform", "href": action_path}
+%a{@tag_attributes, "@click.prevent": "perform", "href": action_path}
   - if block_given?
     = yield

--- a/docs/components/action.md
+++ b/docs/components/action.md
@@ -85,6 +85,34 @@ failure: {
 }
 ```
 
+### ID (optional)
+
+This parameter accepts a string of ids that the action component should have:
+
+```ruby
+id: 'my-action-id'
+```
+
+which renders as an HTML `id` attribute, like so:
+
+```html
+<a id="my-action-id">...</a>
+```
+
+### Class (optional)
+
+This parameter accepts a string of classes that the action component should have:
+
+```ruby
+class: 'my-action-class'
+```
+
+which renders as an HTML `class` attribute, like so:
+
+```html
+<a class="my-action-class">...</a>
+```
+
 ### Notify
 
 Not in use right now.

--- a/spec/usage/components/action_spec.rb
+++ b/spec/usage/components/action_spec.rb
@@ -386,6 +386,33 @@ describe "Action Component", type: :feature, js: true do
 
   end
 
+  it 'accepts class and id attributes and returns them as the corresponding HTML attributes' do
+
+    class ExamplePage < Page::Cell::Page
+
+      def response
+        components {
+          action action_config do
+            button text: "Click me!"
+          end
+        }
+      end
+
+      def action_config
+        return {
+          id: 'action-id',
+          class: 'action-class'
+        }
+      end
+
+    end
+
+    visit "/example"
+
+    expect(page).to have_css('a#action-id.action-class')
+
+  end
+
   it 'action_path: passing path as a string (not recommended)' do
 
     Rails.application.routes.append do


### PR DESCRIPTION
## Fixes https://github.com/basemate/matestack-ui-core/issues/44

### Added
N/A

### Changed
- pass `@tag_attributes` along to action, allowing for `id` and `class` attributes to be defined
- add spec for `class` and `id` in action
- update action documentation to reflect the changes

#### Notes

- The approach that I took now means that the `class` and `id` attributes have to be defined in what is commonly called `action_config`, although this config seems more aimed at the underlying action (the method, the path, success, failure, etc), so I'm not sure if adding the `id` and `class` here will make it seem _cluttered_ or _messy_. Thoughts on this are welcome.
- I tried triggering the Circle build a few times after random failures by using amended commits (I can't trigger a build directly in Circle), but none of them passed, so I will probably need some assistance with that. The relevant specs all pass locally.