### PR TITLE
Add hr link in components readme

### DIFF
--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -12,6 +12,7 @@ You can build your [own components](../extend/custom_components.md) as well, eit
 - [nav](./nav,md)
 - [section](./section.md)
 - [br](./br.md)
+- [hr](./hr.md)
 - [heading](./heading.md)
 - [plain](./plain.md)
 - [pg](./pg.md)


### PR DESCRIPTION
Fixed: An oversight from https://github.com/basemate/matestack-ui-core/pull/49 - missing link to `<hr>` component inside the docs for components