### PR TITLE
Implementing issue 83

### DIFF
--- a/app/concepts/matestack/ui/core/link/link.haml
+++ b/app/concepts/matestack/ui/core/link/link.haml
@@ -1,6 +1,5 @@
-- if options[:text].nil?
-  = link_to link_path, @tag_attributes do
-    - if block_given?
-      = yield
-- else
-  = link_to options[:text], link_path, @tag_attributes
+%a{@tag_attributes}
+  - if options[:text].nil? && block_given?
+    = yield
+  - else
+    = options[:text]

--- a/app/concepts/matestack/ui/core/link/link.rb
+++ b/app/concepts/matestack/ui/core/link/link.rb
@@ -1,6 +1,8 @@
 module Matestack::Ui::Core::Link
   class Link < Matestack::Ui::Core::Component::Static
 
+    REQUIRED_KEYS = [:path]
+
     def setup
       @tag_attributes.merge!({
         "class": options[:class],

--- a/app/concepts/matestack/ui/core/link/link.rb
+++ b/app/concepts/matestack/ui/core/link/link.rb
@@ -1,13 +1,13 @@
 module Matestack::Ui::Core::Link
   class Link < Matestack::Ui::Core::Component::Static
 
-    REQUIRED_KEYS = [:path]
-
     def setup
-      @tag_attributes.merge!({ "class": options[:class],
+      @tag_attributes.merge!({
+        "class": options[:class],
         "id": component_id,
         "method": options[:method],
-        "target": options[:target] ||= nil
+        "target": options[:target] ||= nil,
+        "href": link_path
       })
     end
 

--- a/spec/usage/components/link_spec.rb
+++ b/spec/usage/components/link_spec.rb
@@ -2,39 +2,127 @@ require_relative '../../support/utils'
 include Utils
 
 describe 'Link Component', type: :feature, js: true do
-  # does not work at all. Maybe a problem with the dummy application?
-  # it 'Example 1' do
-  #
-  #   class ExamplePage < Matestack::Ui::Page
-  #
-  #     def response
-  #       components {
-  #         div id: "foo", class: "bar" do
-  #           link path: "https://matestack.org", text: 'here'
-  #         end
-  #         # div id: "foo", class: "bar" do
-  #         #   link path: "https://matestack.org" do
-  #         #     plain 'here'
-  #         #   end
-  #         # end
-  #
-  #       }
-  #     end
-  #
-  #   end
-  #
-  #   visit "/example"
-  #
-  #   sleep 500
-  #   static_output = page.html
-  #
-  #   expected_static_output = <<~HTML
-  #   <div id="foo" class="bar">
-  #     <a href="https://matestack.org">here</a>
-  #   </div>
-  #   HTML
-  #
-  #   expect(stripped(static_output)).to ( include(stripped(expected_static_output)) )
-  # end
+
+  it 'Example 1 - Text Option' do
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          div id: "foo", class: "bar" do
+            link path: "https://matestack.org", text: 'here'
+          end
+        }
+      end
+
+    end
+
+    visit "/example"
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <div id="foo" class="bar">
+      <a href="https://matestack.org">here</a>
+    </div>
+    HTML
+
+    expect(stripped(static_output)).to ( include(stripped(expected_static_output)) )
+  end
+
+  it 'Example 2 - Yield' do
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          div id: "foo", class: "bar" do
+            link path: "https://matestack.org" do
+              plain 'here'
+            end
+          end
+
+        }
+      end
+
+    end
+
+    visit "/example"
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <div id="foo" class="bar">
+      <a href="https://matestack.org">here</a>
+    </div>
+    HTML
+
+    expect(stripped(static_output)).to ( include(stripped(expected_static_output)) )
+  end
+
+  it 'Example 3 - Target' do
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          div id: "foo", class: "bar" do
+            link path: "https://matestack.org", target: "_blank" do
+              plain 'here'
+            end
+          end
+
+        }
+      end
+
+    end
+
+    visit "/example"
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <div id="foo" class="bar">
+      <a href="https://matestack.org" target="_blank">here</a>
+    </div>
+    HTML
+
+    expect(stripped(static_output)).to ( include(stripped(expected_static_output)) )
+  end
+
+  it 'Example 4 - Rails Routing' do
+
+    Rails.application.routes.append do
+      get '/some_link_test_path', to: 'page_test#my_action', as: 'link_test'
+    end
+    Rails.application.reload_routes!
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          div id: "foo", class: "bar" do
+            link path: :link_test_path do
+              plain 'here'
+            end
+          end
+
+        }
+      end
+
+    end
+
+    visit "/example"
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <div id="foo" class="bar">
+      <a href="/some_link_test_path">here</a>
+    </div>
+    HTML
+
+    expect(stripped(static_output)).to ( include(stripped(expected_static_output)) )
+  end
 
 end


### PR DESCRIPTION
## Issue https://github.com/basemate/matestack-ui-core/issues/83: Link Component is broken

### Changes

- fixed link component by removing the `link_to` helper from the link template
- replace it with simple `a` tag
- added specs

