### PR TITLE
Add abbr component with specs and documentation

### DIFF
--- a/app/concepts/matestack/ui/core/abbr/abbr.haml
+++ b/app/concepts/matestack/ui/core/abbr/abbr.haml
@@ -1,0 +1,5 @@
+%abbr{@tag_attributes}
+  - if options[:text].blank? && block_given?
+    = yield
+  - else
+    = options[:text]

--- a/app/concepts/matestack/ui/core/abbr/abbr.rb
+++ b/app/concepts/matestack/ui/core/abbr/abbr.rb
@@ -7,5 +7,6 @@ module Matestack::Ui::Core::Abbr
         "title": options[:title]
       })
     end
+
   end
 end

--- a/app/concepts/matestack/ui/core/abbr/abbr.rb
+++ b/app/concepts/matestack/ui/core/abbr/abbr.rb
@@ -1,0 +1,11 @@
+module Matestack::Ui::Core::Abbr
+  class Abbr < Matestack::Ui::Core::Component::Static
+    REQUIRED_KEYS = [:title]
+
+    def setup
+      @tag_attributes.merge!({
+        "title": options[:title]
+      })
+    end
+  end
+end

--- a/docs/components/abbr.md
+++ b/docs/components/abbr.md
@@ -1,0 +1,48 @@
+# matestack core component: abbr
+
+Show [specs](../../spec/usage/components/abbr_spec.rb)
+
+The HTML `abbr` tag implemented in ruby.
+
+## Parameters
+
+This component expects 1 required param, 2 optional configuration params and either yield content or display what gets passed to the `text` configuration param.
+
+#### # title
+Expects a string with the meaning of the abbreviation contained within the tag.
+
+#### # id - optional
+Expects a string with all ids the `abbr` should have.
+
+#### # class - optional
+Expects a string with all classes the `abbr` should have.
+
+
+## Example 1 - render options[:text] param
+
+```ruby
+abbr title: 'Hypertext Markup Language', text: 'HTML'
+```
+
+returns
+
+```html
+<abbr title="Hypertext Markup Language">HTML</abbr>
+```
+
+
+## Example 2 - yield a given block
+
+```ruby
+abbr title: 'Cascading Style Sheets' do
+  span do
+    plain 'CSS'
+  end
+end
+```
+
+returns
+
+```html
+<abbr title="Cascading Style Sheets">CSS</abbr>
+```

--- a/docs/components/abbr.md
+++ b/docs/components/abbr.md
@@ -8,7 +8,7 @@ The HTML `abbr` tag implemented in ruby.
 
 This component expects 1 required param, 2 optional configuration params and either yield content or display what gets passed to the `text` configuration param.
 
-#### # title
+#### # title - required
 Expects a string with the meaning of the abbreviation contained within the tag.
 
 #### # id - optional
@@ -17,6 +17,8 @@ Expects a string with all ids the `abbr` should have.
 #### # class - optional
 Expects a string with all classes the `abbr` should have.
 
+#### # text - optional
+Expects a string which will be displayed as the content inside the `abbr`. If this is not passed, a block must be passed instead.
 
 ## Example 1 - render options[:text] param
 
@@ -35,9 +37,7 @@ returns
 
 ```ruby
 abbr title: 'Cascading Style Sheets' do
-  span do
-    plain 'CSS'
-  end
+  span text: 'CSS'
 end
 ```
 

--- a/spec/usage/components/abbr_spec.rb
+++ b/spec/usage/components/abbr_spec.rb
@@ -33,9 +33,7 @@ describe 'Abbr Component', type: :feature, js: true do
       def response
         components {
           abbr title: 'Cascading Style Sheets' do
-            span do
-              plain 'CSS'
-            end
+            span text: 'CSS'
           end
         }
       end

--- a/spec/usage/components/abbr_spec.rb
+++ b/spec/usage/components/abbr_spec.rb
@@ -1,0 +1,56 @@
+require_relative '../../support/utils'
+include Utils
+
+describe 'Abbr Component', type: :feature, js: true do
+
+  it 'Example 1' do
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          abbr title: 'Hypertext Markup Language', text: 'HTML'
+        }
+      end
+
+    end
+
+    visit '/example'
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <abbr title="Hypertext Markup Language">HTML</abbr>
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+
+  it 'Example 2' do
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          abbr title: 'Cascading Style Sheets' do
+            span do
+              plain 'CSS'
+            end
+          end
+        }
+      end
+
+    end
+
+    visit '/example'
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <abbr title="Cascading Style Sheets"><span>CSS</span></abbr>
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+
+end


### PR DESCRIPTION
## Issue https://github.com/basemate/matestack-ui-core/issues/116: abbr tag

### Changes

- [x] add `abbr` tag
- [x] add `abbr` documentation
- [x] add `abbr` specs
