### PR TITLE
Fix issue #208: Add HTML <q> tag to core components

### DIFF
--- a/app/concepts/matestack/ui/core/q/q.haml
+++ b/app/concepts/matestack/ui/core/q/q.haml
@@ -1,0 +1,5 @@
+%q{@tag_attributes}
+  - if block_given?
+    = yield
+  - else
+    = options[:text]

--- a/app/concepts/matestack/ui/core/q/q.rb
+++ b/app/concepts/matestack/ui/core/q/q.rb
@@ -1,0 +1,11 @@
+module Matestack::Ui::Core::Q
+  class Q < Matestack::Ui::Core::Component::Static
+
+    def setup
+      @tag_attributes.merge!({
+        "cite": options[:cite]
+        })
+    end
+
+  end
+end

--- a/docs/components/blockquote.md
+++ b/docs/components/blockquote.md
@@ -9,10 +9,10 @@ The HTML blockquote tag implemented in ruby.
 This component can take 3 optional configuration params and either yield content or display what gets passed to the `text` configuration param.
 
 #### # id (optional)
-Expects a string with all ids the span should have.
+Expects a string with all ids the blockquote should have.
 
 #### # class (optional)
-Expects a string with all classes the span should have.
+Expects a string with all classes the blockquote should have.
 
 #### # cite (optional)
 Expects a string referencing a cite for the blockquote.

--- a/docs/components/q.md
+++ b/docs/components/q.md
@@ -1,0 +1,50 @@
+# matestack core component: Q
+
+Show [specs](../../spec/usage/components/q_spec.rb)
+
+The HTML q tag implemented in ruby.
+
+## Parameters
+
+This component can take 4 optional configuration params and either yield content or display what gets passed to the `text` configuration param.
+
+#### # id (optional)
+Expects a string with all ids the quote should have.
+
+#### # class (optional)
+Expects a string with all classes the quote should have.
+
+#### # text (optional)
+Expects a string with the text that should go into the `<q>` tag.
+
+#### # cite (optional)
+Expects a string for referencing the source for the quote.
+
+## Example 1: Yield a given block
+
+```ruby
+q id: "foo", class: "bar" do
+  plain 'Hello World' # optional content
+end
+```
+
+returns
+
+```html
+<q id="foo" class="bar">
+  Hello World
+</q>
+```
+
+## Example 2: Render options[:text] param
+
+```ruby
+q id: "foo", class: "bar", cite: "helloworld.io" text: 'Hello World'
+```
+
+returns
+
+```html
+<q id="foo" class="bar" cite="helloworld.io">
+  Hello World
+</q>

--- a/spec/usage/components/q_spec.rb
+++ b/spec/usage/components/q_spec.rb
@@ -1,0 +1,39 @@
+require_relative "../../support/utils"
+include Utils
+
+describe "Q Component", type: :feature, js: true do
+
+  it "Example 1" do
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          #simple q
+          q text: "A simple quote"
+
+          # enhanced q
+          q id: 'my-id', class: 'my-class', cite: 'www.matestack.org/example' do
+            plain 'This is a enhanced q with text'
+          end
+        }
+      end
+
+    end
+
+    visit "/example"
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <q>A simple quote</q>
+
+    <q id="my-id" class="my-class"></q>
+
+    <q cite="www.matestack.org/example" id="my-id" class="my-class">This is a enhanced q with text</q>
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+
+end

--- a/spec/usage/components/q_spec.rb
+++ b/spec/usage/components/q_spec.rb
@@ -27,9 +27,6 @@ describe "Q Component", type: :feature, js: true do
 
     expected_static_output = <<~HTML
     <q>A simple quote</q>
-
-    <q id="my-id" class="my-class"></q>
-
     <q cite="www.matestack.org/example" id="my-id" class="my-class">This is a enhanced q with text</q>
     HTML
 


### PR DESCRIPTION
## Issue https://github.com/basemate/matestack-ui-core/issues/208: Add HTML <q> tag to core components

### Changes

- Created q folder, q.haml and q.rb files to matestack ui core components
- Created q.md to docs > components
- Created q_spec.rb to usage > components

### Notes

- Nothing here