### PR TITLE
Add HTML <em> tag to core components

### DIFF
--- a/app/concepts/matestack/ui/core/em/em.haml
+++ b/app/concepts/matestack/ui/core/em/em.haml
@@ -1,0 +1,5 @@
+%em{@tag_attributes}
+  - if options[:text].nil? && block_given?
+    = yield
+  - else
+    = options[:text]

--- a/app/concepts/matestack/ui/core/em/em.rb
+++ b/app/concepts/matestack/ui/core/em/em.rb
@@ -1,0 +1,5 @@
+module Matestack::Ui::Core::Em
+  class Em < Matestack::Ui::Core::Component::Static
+
+  end
+end

--- a/docs/components/em.md
+++ b/docs/components/em.md
@@ -1,4 +1,4 @@
-# matestack core component: Small
+# matestack core component: Em
 
 Show [specs](/spec/usage/components/em_spec.rb)
 

--- a/docs/components/em.md
+++ b/docs/components/em.md
@@ -1,0 +1,40 @@
+# matestack core component: Small
+
+Show [specs](/spec/usage/components/em_spec.rb)
+
+The HTML em tag implemented in Ruby.
+
+## Parameters
+
+This component can take 2 optional configuration params and either yield content or display what gets passed to the `text` configuration param.
+
+#### # id (optional)
+Expects a string with all ids the em tag should have.
+
+#### # class (optional)
+Expects a string with all classes the em tag should have.
+
+## Example 1: Yield a given block
+
+```ruby
+em id: "foo", class: "bar" do
+  plain 'Emphasized text' # optional content
+end
+```
+
+returns
+
+```html
+<em id="foo" class="bar">Emphasized text</small>
+```
+
+## Example 2: Render options[:text] param
+
+```ruby
+em id: "foo", class: "bar", text: 'Emphasized text'
+```
+
+returns
+
+```html
+<em id="foo" class="bar">Emphasized text</small>

--- a/spec/usage/components/em_spec.rb
+++ b/spec/usage/components/em_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative '../../support/utils'
+include Utils
+
+describe 'Em Component', type: :feature, js: true do
+  it 'Example 1 - yield, no options[:text]' do
+    class ExamplePage < Matestack::Ui::Page
+      def response
+        components do
+          # simple em tag
+          em do
+            plain 'Emphasized text'
+          end
+
+          # enhanced em tag
+          em id: 'my-id', class: 'my-class' do
+            plain 'Enhanced emphasized text'
+          end
+        end
+      end
+    end
+
+    visit '/example'
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+      <em>Emphasized text</em>
+      <em id="my-id" class="my-class">Enhanced emphasized text</em>
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+
+  it 'Example 2 - render options[:text]' do
+    class ExamplePage < Matestack::Ui::Page
+      def response
+        components do
+          # simple em
+          em text: 'Emphasized text'
+
+          # enhanced em
+          em id: 'my-id', class: 'my-class', text: 'Enhanced emphasized text'
+        end
+      end
+    end
+
+    visit '/example'
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+      <em>Emphasized text</em>
+      <em id="my-id" class="my-class">Enhanced emphasized text</em>
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+end


### PR DESCRIPTION
Closes #188 

## Issue https://github.com/basemate/matestack-ui-core/issues/188: Add HTML `<em>` tag to core components

### Changes

- [x] Adds HTML `<em>` tag core component + spec
