### PR TITLE
Issue 163 fix

### DIFF
--- a/app/concepts/matestack/ui/core/b/b.haml
+++ b/app/concepts/matestack/ui/core/b/b.haml
@@ -1,0 +1,5 @@
+%b{@tag_attributes}
+  - if options[:text].nil? && block_given?
+    = yield
+  - else
+    = options[:text]

--- a/app/concepts/matestack/ui/core/b/b.rb
+++ b/app/concepts/matestack/ui/core/b/b.rb
@@ -1,0 +1,5 @@
+module Matestack::Ui::Core::B
+  class B < Matestack::Ui::Core::Component::Static
+
+  end
+end

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -17,6 +17,7 @@ You can build your [own components](/docs/extend/custom_components.md) as well, 
 - [plain](/docs/components/plain.md)
 - [pg](/docs/components/pg.md)
 - [span](/docs/components/span.md)
+- [b](/docs/components/b.md)
 - [icon](/docs/components/icon.md)
 - [list](/docs/components/list.md)
   - ul

--- a/docs/components/b.md
+++ b/docs/components/b.md
@@ -1,0 +1,44 @@
+# matestack core component: B
+
+Show [specs](/spec/usage/components/b_spec.rb)
+
+The HTML b tag implemented in ruby.
+
+## Parameters
+
+This component can take 2 optional configuration params and either yield content or display what gets passed to the `text` configuration param.
+
+#### # id (optional)
+Expects a string with all ids the b should have.
+
+#### # class (optional)
+Expects a string with all classes the b should have.
+
+## Example 1: Yield a given block
+
+```ruby
+b id: "foo", class: "bar" do
+  plain 'Hello World' # optional content
+end
+```
+
+returns
+
+```html
+<b id="foo" class="bar">
+  Hello World
+</b>
+```
+
+## Example 2: Render options[:text] param
+
+```ruby
+b id: "foo", class: "bar", text: 'Hello World'
+```
+
+returns
+
+```html
+<b id="foo" class="bar">
+  Hello World
+</b>

--- a/docs/components/video.md
+++ b/docs/components/video.md
@@ -8,19 +8,19 @@ The HTML video tag implemented in ruby.
 The video tag takes a mandatory path argument and can take a number of optional configuration params.
 
 #### # path
-Expects a string with the source to the image. It looks for the image in the `assets/videos` folder and uses the standard Rails asset pipeline.
+Expects a string with the source to the video. It looks for the video in the `assets/videos` folder and uses the standard Rails asset pipeline.
 
 #### # id, class
 Like most of the core components, you can give a video an id and a class.
 
 #### # height (optional)
-Expects an integer with the height of the image in px.
+Expects an integer with the height of the video in px.
 
 #### # width (optional)
-Expects an integer with the width of the image in px.
+Expects an integer with the width of the video in px.
 
 #### # alt (optional)
-Expects a string with the alt text the image should have.
+Expects a string with the alt text the video should have.
 
 #### # preload
 Expects a string (`auto`, `metadata` or `none`) and specifies whether the whole video/only metadata/nothing should be loaded on pageload. Default (if not specified) depends on the client's browser.

--- a/spec/usage/components/b_spec.rb
+++ b/spec/usage/components/b_spec.rb
@@ -1,0 +1,66 @@
+require_relative "../../support/utils"
+include Utils
+
+describe 'B Component', type: :feature, js: true do
+
+  it 'Example 1 - yield, no options[:text]' do
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          # simple b
+          b do
+            plain 'I am simple'
+          end
+
+          # enhanced b
+          b id: 'my-id', class: 'my-class' do
+            plain 'I am enhanced'
+          end
+        }
+      end
+
+    end
+
+    visit '/example'
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <b>I am simple</b>
+    <b id="my-id" class="my-class">I am enhanced</b>
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+
+  it 'Example 2 - render options[:text]' do
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          # simple b
+          b text: 'I am simple'
+
+          # enhanced b
+          b id: 'my-id', class: 'my-class',text: 'I am enhanced'
+        }
+      end
+
+    end
+
+    visit '/example'
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <b>I am simple</b>
+    <b id="my-id" class="my-class">I am enhanced</b>
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+
+end


### PR DESCRIPTION
**Please make sure to target feature and bugfix requests to develop branch**

## Issue https://github.com/basemate/matestack-ui-core/issues/163: Add HTML bold tag to core components

### Changes

- Added b.haml and b.rb to app/concepts/matestack/ui/core/b
- Added b.md to docs/components/b.md
- Modified docs/components/README.md : added reference to b tag
- Added spec/usage/components/b_spec.rb test

### Notes

- I've noticed that the docs/components/README.md is missing a lot of links to components
