### PR TITLE
Fix typos in docs/components/em.md

### DIFF
--- a/docs/components/em.md
+++ b/docs/components/em.md
@@ -25,7 +25,7 @@ end
 returns
 
 ```html
-<em id="foo" class="bar">Emphasized text</small>
+<em id="foo" class="bar">Emphasized text</em>
 ```
 
 ## Example 2: Render options[:text] param
@@ -37,4 +37,4 @@ em id: "foo", class: "bar", text: 'Emphasized text'
 returns
 
 ```html
-<em id="foo" class="bar">Emphasized text</small>
+<em id="foo" class="bar">Emphasized text</em>


### PR DESCRIPTION
There is no issue for this but I notice that in `docs/components/em.md`, em tag is closed with `</small>`

### Changes
- [x] Changed `</small>` to `</em>`