### PR TITLE
add pre tag

### DIFF
--- a/app/concepts/matestack/ui/core/pre/pre.haml
+++ b/app/concepts/matestack/ui/core/pre/pre.haml
@@ -1,0 +1,5 @@
+%pre{@tag_attributes}
+  - if options[:text].nil? && block_given?
+    = yield
+  - else
+    = options[:text]

--- a/app/concepts/matestack/ui/core/pre/pre.rb
+++ b/app/concepts/matestack/ui/core/pre/pre.rb
@@ -1,0 +1,5 @@
+module Matestack::Ui::Core::Pre
+  class Pre < Matestack::Ui::Core::Component::Static
+
+  end
+end

--- a/docs/components/pre.md
+++ b/docs/components/pre.md
@@ -1,0 +1,47 @@
+# matestack core component: Pre
+
+Show [specs](/spec/usage/components/pre_spec.rb)
+
+The HTML pre tag implemented in ruby.
+
+## Parameters
+
+This component can take 3 optional configuration params and either yield content or display what gets passed to the `text` configuration param.
+
+#### # id (optional)
+Expects a string with all ids the pre should have.
+
+#### # class (optional)
+Expects a string with all classes the pre should have.
+
+#### # text (optional)
+Expects a ruby string with the text the address tag should show.
+
+## Example 1: Yield a given block
+
+```ruby
+pre id: "foo", class: "bar" do
+  plain 'Hello World' # optional content
+end
+```
+
+returns
+
+```html
+<pre id="foo" class="bar">
+  Hello World
+</pre>
+```
+
+## Example 2: Render options[:text] param
+
+```ruby
+pre id: "foo", class: "bar", text: 'Hello World'
+```
+
+returns
+
+```html
+<pre id="foo" class="bar">
+  Hello World
+</pre>

--- a/spec/usage/components/pre_spec.rb
+++ b/spec/usage/components/pre_spec.rb
@@ -1,0 +1,46 @@
+require_relative '../../support/utils'
+include Utils
+
+describe 'Pre Component', type: :feature, js: true do
+  it 'Example 1 - yield a given block' do
+    class ExamplePage < Matestack::Ui::Page
+      def response
+        components {
+          pre do
+            plain 'This is preformatted text'
+          end
+        }
+      end
+    end
+
+    visit '/example'
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+      <pre>This is preformatted text</pre>
+    HTML
+    p stripped(static_output)
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+
+  it 'Example 2 - render options[:text] param' do
+    class ExamplePage < Matestack::Ui::Page
+      def response
+        components {
+          pre text: 'This is preformatted text'
+        }
+      end
+    end
+
+    visit '/example'
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+      <pre>This is preformatted text</pre>
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+ end
+end


### PR DESCRIPTION
## Issue https://github.com/basemate/matestack-ui-core/issues/207 Add HTML pre tag to core components

### Changes

- [x] Adds pre tag core component with doc and spec
