### PR TITLE
Prepare rails 6 usage

### DIFF
--- a/app/concepts/matestack/ui/core/app/app.rb
+++ b/app/concepts/matestack/ui/core/app/app.rb
@@ -17,7 +17,6 @@ module Matestack::Ui::Core::App
     include ActionView::Helpers::JavaScriptHelper
     include ActionView::Helpers::NumberHelper
     include ActionView::Helpers::OutputSafetyHelper
-    include ActionView::Helpers::RecordTagHelper
     # include ActionView::Helpers::RenderingHelper
     include ActionView::Helpers::SanitizeHelper
     include ActionView::Helpers::TagHelper

--- a/app/concepts/matestack/ui/core/component/dynamic.rb
+++ b/app/concepts/matestack/ui/core/component/dynamic.rb
@@ -18,7 +18,6 @@ module Matestack::Ui::Core::Component
     include ActionView::Helpers::JavaScriptHelper
     include ActionView::Helpers::NumberHelper
     include ActionView::Helpers::OutputSafetyHelper
-    include ActionView::Helpers::RecordTagHelper
     # include ActionView::Helpers::RenderingHelper
     include ActionView::Helpers::SanitizeHelper
     include ActionView::Helpers::TagHelper

--- a/app/concepts/matestack/ui/core/view/view.rb
+++ b/app/concepts/matestack/ui/core/view/view.rb
@@ -1,4 +1,4 @@
-module Matestack::Ui::Core::View::Cell
+module Matestack::Ui::Core::View
     class View < Matestack::Ui::Core::Component::Dynamic
 
   end

--- a/app/lib/matestack/ui/view.rb
+++ b/app/lib/matestack/ui/view.rb
@@ -1,0 +1,1 @@
+Matestack::Ui::View = Matestack::Ui::Core::View::View

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -107,3 +107,37 @@ returns
   </a>
 </div>
 ```
+
+## Example 5 - path from symbol
+This example renders a link with a get request to any within your Rails application. In case you want to switch between pages within one specific matestack app, using the `transition` component probably is a better idea though!
+
+```ruby
+div id: "foo", class: "bar" do
+  link path: :inline_edit_path, text: 'Click to edit'
+end
+```
+
+returns
+
+```html
+<div id="foo" class="bar">
+  <a href="/inline_edit">Click to edit</a>
+</div>
+```
+
+## Example 6 - path from symbol with params
+You can also dynamically create `paths` from symbols and params, as displayed below:
+
+```ruby
+div id: "foo", class: "bar" do
+  link path: :single_endpoint_path, params: {number: 1}, text: 'Call API endpoint 1'
+end
+```
+
+returns
+
+```html
+<div id="foo" class="bar">
+  <a href="/api/single_endpoint/1">Call API endpoint 1</a>
+</div>
+```

--- a/spec/dummy/app/controllers/api_controller.rb
+++ b/spec/dummy/app/controllers/api_controller.rb
@@ -4,4 +4,9 @@ class ApiController < ApplicationController
     render json: ["some", "server", "data"]
   end
 
+  def single_endpoint
+    user = "user number #{params[:number]}"
+    render json: [user]
+  end
+
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
 
   scope :api do
     get 'data', to: 'api#data'
+    get 'data/:number', to: 'api#single_endpoint', as: "single_endpoint"
   end
 
 end

--- a/spec/dummy/yarn.lock
+++ b/spec/dummy/yarn.lock
@@ -3514,6 +3514,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"

--- a/spec/usage/components/link_spec.rb
+++ b/spec/usage/components/link_spec.rb
@@ -125,4 +125,58 @@ describe 'Link Component', type: :feature, js: true do
     expect(stripped(static_output)).to ( include(stripped(expected_static_output)) )
   end
 
+  it 'Example 5 - Rails Routing using symbols' do
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          div id: "foo", class: "bar" do
+            link text: 'Click', path: :inline_edit_path
+          end
+        }
+      end
+
+    end
+
+    visit "/example"
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <div id="foo" class="bar">
+      <a href="/my_app/inline_edit">Click</a>
+    </div>
+    HTML
+
+    expect(stripped(static_output)).to ( include(stripped(expected_static_output)) )
+  end
+
+  it 'Example 6 - Rails Routing using symbols with params' do
+
+    class ExamplePage < Matestack::Ui::Page
+
+      def response
+        components {
+          div id: "foo", class: "bar" do
+            link path: :single_endpoint_path, params: {number: 1}, text: 'Call API endpoint 1'
+          end
+
+        }
+      end
+
+    end
+    visit "/example"
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <div id="foo" class="bar">
+      <a href="/api/data/1">Call API endpoint 1</a>
+    </div>
+    HTML
+
+    expect(stripped(static_output)).to ( include(stripped(expected_static_output)) )
+  end
+
 end


### PR DESCRIPTION
## Issue https://github.com/basemate/matestack-ui-core/issues/240: Prepare Matestack for Usage with Rails 6

### Changes

- [x] Modified `view` component as it was causing errors
- [x] Removed unnecessary, trouble-causing helpers (#146)

### Problems

- Rails 6 does use a different way of handling `.js` assets. They aren't placed in the `assets/javascript/application.js` anymore, but live in `javascript/packs/application.js`. There, I tried to add a modified `require("matestack-ui-core")`, but this didn't work.

Additional help is needed!
