### PR TITLE
Remove unused helper, fixes#146

### DIFF
--- a/app/concepts/matestack/ui/core/app/app.rb
+++ b/app/concepts/matestack/ui/core/app/app.rb
@@ -17,7 +17,6 @@ module Matestack::Ui::Core::App
     include ActionView::Helpers::JavaScriptHelper
     include ActionView::Helpers::NumberHelper
     include ActionView::Helpers::OutputSafetyHelper
-    include ActionView::Helpers::RecordTagHelper
     # include ActionView::Helpers::RenderingHelper
     include ActionView::Helpers::SanitizeHelper
     include ActionView::Helpers::TagHelper

--- a/app/concepts/matestack/ui/core/component/dynamic.rb
+++ b/app/concepts/matestack/ui/core/component/dynamic.rb
@@ -18,7 +18,6 @@ module Matestack::Ui::Core::Component
     include ActionView::Helpers::JavaScriptHelper
     include ActionView::Helpers::NumberHelper
     include ActionView::Helpers::OutputSafetyHelper
-    include ActionView::Helpers::RecordTagHelper
     # include ActionView::Helpers::RenderingHelper
     include ActionView::Helpers::SanitizeHelper
     include ActionView::Helpers::TagHelper


### PR DESCRIPTION
## Issue https://github.com/basemate/matestack-ui-core/issues/146: Remove RecordTagHelper

### Changes

- [x] Remove RecordTagHelper from `component/dynamic.rb` and `app/app.rb`