### PR TITLE
add mark matestack core component

### DIFF
--- a/app/concepts/matestack/ui/core/mark/mark.haml
+++ b/app/concepts/matestack/ui/core/mark/mark.haml
@@ -1,0 +1,5 @@
+%mark{@tag_attributes}
+  - if options[:text].blank? && block_given?
+    = yield
+  - else
+    = options[:text]

--- a/app/concepts/matestack/ui/core/mark/mark.rb
+++ b/app/concepts/matestack/ui/core/mark/mark.rb
@@ -1,0 +1,4 @@
+module Matestack::Ui::Core::Mark
+  class Mark < Matestack::Ui::Core::Component::Static
+  end
+end

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -41,6 +41,7 @@ You can build your [own components](/docs/extend/custom_components.md) as well, 
 - [sup](/docs/components/sup.md)
 - [sub](/docs/components/sub.md)
 - [kbd](/docs/components/kbd.md)
+- [mark](/docs/components/mark.md)
 
 ## Dynamic Core Components
 

--- a/docs/components/mark.md
+++ b/docs/components/mark.md
@@ -1,0 +1,44 @@
+# matestack core component: Mark
+
+Show [specs](/spec/usage/components/mark_spec.rb)
+
+The HTML `<mark>` tag implemented in ruby.
+
+## Parameters
+
+This component can take 2 optional configuration params and either yield content or display what gets passed to the `text` configuration param.
+
+#### # id (optional)
+Expects a string with all ids the `<mark>` should have.
+
+#### # class (optional)
+Expects a string with all classes the `<mark>` should have.
+
+## Example 1: Yield a given block
+
+```ruby
+mark id: 'foo', class: 'bar' do
+  plain 'Mark Example 1' # optional content
+end
+```
+
+returns
+
+```html
+<mark id="foo" class="bar">
+  Mark Example 1
+</mark>
+```
+
+## Example 2: Render `options[:text]` param
+
+```ruby
+mark id: 'foo', class: 'bar', text: 'Mark Example 2'
+```
+
+returns
+
+```html
+<mark id="foo" class="bar">
+  Mark Example 2
+</mark>

--- a/spec/usage/components/mark_spec.rb
+++ b/spec/usage/components/mark_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../../support/utils'
+include Utils
+
+describe 'mark Component', type: :feature, js: true do
+  it 'Renders a simple and enhanced mark tag on a page' do
+    class ExamplePage < Matestack::Ui::Page
+      def response
+        components {
+          # simple mark
+          mark text: 'Simple mark Tag'
+
+          # enhanced mark
+          mark id: 'my-id', class: 'my-class' do
+            plain 'Enhanced mark Tag'
+          end
+        }
+      end
+    end
+
+    visit '/example'
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+      <mark>Simple mark Tag</mark>
+      <mark id="my-id" class="my-class">Enhanced mark Tag</mark>
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+end


### PR DESCRIPTION
Closes #198

## Issue #198: mark component

Add HTML `<mark>` tag to core components

### Changes

 - [x] Add mark component
 - [x] Add specs
 - [x] Add docs