### PR TITLE
Label component bug

### DIFF
--- a/app/concepts/matestack/ui/core/label/label.rb
+++ b/app/concepts/matestack/ui/core/label/label.rb
@@ -2,7 +2,8 @@ module Matestack::Ui::Core::Label
   class Label < Matestack::Ui::Core::Component::Static
     def setup
       @tag_attributes.merge!({
-        for: options[:for]
+        for: options[:for],
+        form: options[:form]
       })
     end
   end

--- a/app/concepts/matestack/ui/core/label/label.rb
+++ b/app/concepts/matestack/ui/core/label/label.rb
@@ -1,5 +1,9 @@
 module Matestack::Ui::Core::Label
   class Label < Matestack::Ui::Core::Component::Static
-
+    def setup
+      @tag_attributes.merge!({
+        for: options[:for]
+      })
+    end
   end
 end

--- a/docs/components/label.md
+++ b/docs/components/label.md
@@ -16,14 +16,20 @@ Expects a string with all ids the div should have.
 Expects a string with all classes the div should have.
 
 #### # for (optional)
-Expects a string that binds the label to a given form element
+Expects a string that binds the label to a given form element (To match `id` of form element)
+
+#### # form (optional)
+Expects a string that specifies which form or forms the label belongs to.
 
 ## Example
 
 ```ruby
-label id: "foo", class: "bar", for: 'input_id' do
+label id: "foo", class: "bar", for: 'input_id', form: 'form1' do
   plain 'Label For Element' # optional content
 end
+
+label id: 'foo', form: 'form1', text: "Label for form with id='form1'"
+
 ```
 
 returns
@@ -32,5 +38,8 @@ returns
 <label for="input_id" id="foo" class="bar">
   Label For Element
 </label>
+
+<label form="form1" id="foo">Label for form with id='form1'</label>
+
 ```
 

--- a/docs/components/label.md
+++ b/docs/components/label.md
@@ -1,3 +1,36 @@
 # matestack core component: Label
 
 Show [specs](/spec/usage/components/label_spec.rb)
+
+
+The HTML label tag implemented in ruby.
+
+## Parameters
+
+This component can take 3 optional configuration params and optional content.
+
+#### # id (optional)
+Expects a string with all ids the div should have.
+
+#### # class (optional)
+Expects a string with all classes the div should have.
+
+#### # for (optional)
+Expects a string that binds the label to a given form element
+
+## Example
+
+```ruby
+label id: "foo", class: "bar", for: 'input_id' do
+  plain 'Label For Element' # optional content
+end
+```
+
+returns
+
+```html
+<label for="input_id" id="foo" class="bar">
+  Label For Element
+</label>
+```
+

--- a/spec/usage/components/label_spec.rb
+++ b/spec/usage/components/label_spec.rb
@@ -13,7 +13,7 @@ describe 'Label Component', type: :feature, js: true do
           label text: 'I am simple'
 
           # enhanced label
-          label id: 'my-id', class: 'my-class' do
+          label id: 'my-id', for: 'label for something', class: 'my-class' do
             plain 'I am enhanced'
           end
         }
@@ -27,7 +27,7 @@ describe 'Label Component', type: :feature, js: true do
 
     expected_static_output = <<~HTML
     <label>I am simple</label>
-    <label id="my-id" class="my-class">I am enhanced</label>
+    <label for="label for something" id="my-id" class="my-class">I am enhanced</label>
     HTML
 
     expect(stripped(static_output)).to include(stripped(expected_static_output))

--- a/spec/usage/components/label_spec.rb
+++ b/spec/usage/components/label_spec.rb
@@ -16,6 +16,9 @@ describe 'Label Component', type: :feature, js: true do
           label id: 'my-id', for: 'label for something', class: 'my-class' do
             plain 'I am enhanced'
           end
+
+          # with form attribute
+          label id: 'form_label', for: "form", form: 'form1', text: 'Label for Form1'
         }
       end
 
@@ -28,6 +31,8 @@ describe 'Label Component', type: :feature, js: true do
     expected_static_output = <<~HTML
     <label>I am simple</label>
     <label for="label for something" id="my-id" class="my-class">I am enhanced</label>
+
+    <label for="form" form="form1" id="form_label" >Label for Form 1</label>
     HTML
 
     expect(stripped(static_output)).to include(stripped(expected_static_output))


### PR DESCRIPTION
**Please make sure to target feature and bugfix requests to develop branch**

## Issue https://github.com/basemate/matestack-ui-core/issues/262: 
Update label stand alone component to accept `for` attribute for correct element binding

### Changes

- [x] updated docs
- [x] updated label (rb)
- [x] updated specs (rb)

