### PR TITLE
add note for running tests on macOS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development, :test do
   gem 'simplecov', require: false, group: :test
   gem 'byebug'
   gem 'webmock'
+  gem 'webdrivers', '~> 4.1'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,10 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.1.0)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -264,6 +268,7 @@ DEPENDENCIES
   trailblazer
   trailblazer-cells
   trailblazer-rails
+  webdrivers (~> 4.1)
   webmock
   webpacker (~> 3.5)
 

--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -55,6 +55,26 @@ bundle exec rspec
 
 Tests follow quite the same rules as the documentation: Make sure to either add relevant tests (when introducing new concepts or components) or change existing ones to fit your changes (updating existing concepts and components). Pull requests that add/change concepts & components and do not come with corresponding tests will not be approved.
 
+### Note: Running tests on macOS
+
+Make sure you have installed `chromedriver` on your machine. You can install `chromedriver` via `brew` with
+
+```shell
+brew cask install chromedriver
+```
+
+You can then run your the testsuite with `bundle exec rspec`.
+
+If you get an error about a version mismatch similar to this one:
+
+`Chrome version must be between X and Y (Driver info: chromedriver=X.Y.Z)`
+
+Make sure you update your chromedriver by executing this command in the project root:
+
+```shell
+rails app:webdrivers:chromedriver:update
+```
+
 ## Release
 
 Webpacker is used for managing all JS assets. In order to deploy a packed JS, we use a "builder" app found in `repo_root/builder`. This builder app uses a symlink in order to reference the actual core found in `builder/vendor`.


### PR DESCRIPTION
Closes #241

## Issue #241: Add documentation for testing on macOS

This PR adds a note to the contribute docs on how to setup your development machine to run tests on macOS.

### Changes

 - [x] Adds gem `webdrivers `
 - [x] Adds note to contribute docs