### PR TITLE
Add map and area component

### DIFF
--- a/app/concepts/matestack/ui/core/area/area.haml
+++ b/app/concepts/matestack/ui/core/area/area.haml
@@ -1,0 +1,1 @@
+%area{@tag_attributes}

--- a/app/concepts/matestack/ui/core/area/area.rb
+++ b/app/concepts/matestack/ui/core/area/area.rb
@@ -1,0 +1,18 @@
+module Matestack::Ui::Core::Area
+  class Area < Matestack::Ui::Core::Component::Static
+    def setup
+      @tag_attributes.merge!({
+        alt: options[:alt],
+        coords: options[:coords].join(','),
+        download: options[:download],
+        href: options[:href],
+        hreflang: options[:hreflang],
+        media: options[:media],
+        rel: options[:rel],
+        shape: options[:shape],
+        target: options[:target],
+        type: options[:type]
+      })
+    end
+  end
+end

--- a/app/concepts/matestack/ui/core/img/img.rb
+++ b/app/concepts/matestack/ui/core/img/img.rb
@@ -6,6 +6,7 @@ module Matestack::Ui::Core::Img
         src: ActionController::Base.helpers.asset_path(options[:path]),
         height: options[:height],
         width: options[:width],
+        usemap: options[:usemap],
         alt: options[:alt]
       })
     end

--- a/app/concepts/matestack/ui/core/map/map.haml
+++ b/app/concepts/matestack/ui/core/map/map.haml
@@ -1,0 +1,3 @@
+%map{@tag_attributes}
+  - if block_given?
+    = yield

--- a/app/concepts/matestack/ui/core/map/map.rb
+++ b/app/concepts/matestack/ui/core/map/map.rb
@@ -1,0 +1,11 @@
+module Matestack::Ui::Core::Map
+  class Map < Matestack::Ui::Core::Component::Static
+    REQUIRED_KEYS = [:name]
+
+    def setup
+      @tag_attributes.merge!({
+        name: options[:name]
+      })
+    end
+  end
+end

--- a/docs/components/area.md
+++ b/docs/components/area.md
@@ -1,0 +1,62 @@
+# matestack core component: Area
+
+Tested within the [map specs](/spec/usage/components/map_spec.rb).
+
+The HTML `<area>` tag implemented in Ruby.
+
+## Parameters
+This component takes up to 10 optional configuration params. It is meant to be used within the `<map>` component.
+
+#### # alt (optional)
+Expects a string that specifies an alternate text for the `<area>`. Required if the href attribute is present.
+
+#### # coords (optional)
+Expects an array of integers that define the `<area>`'s coordinates. For more details, see the [official documentation](https://www.w3schools.com/tags/att_area_coords.asp).
+
+#### # download (optional)
+Expects a string to specify the target that will be downloaded when a user clicks on the hyperlink.
+
+#### # href (optional)
+Expects a string to specify the hyperlink target for the area.
+
+#### # hreflang (optional)
+Expects a string to specify the language of the target URL.
+
+#### # media (optional)
+Expects a string to specify what media/device the target URL is optimized for.
+
+#### # rel (optional)
+Expects a string to specify the relationship between the current document and the target URL.
+
+#### # shape (optional)
+Expects a string to specify the shape of the area: Default, rect, circle, poly.
+
+#### # target (optional)
+Expects a string to specify where to open the target URL.
+
+#### # type (optional)
+Expects a string to specify the media type of the target URL.
+
+## Example:
+
+```ruby
+img path: 'matestack-logo.png', width: 500, height: 300, alt: "otherlogo",  usemap: "#newmap"
+
+map name: 'newmap' do
+  area shape: 'rect', coords: [0,0,100,100], href: 'first.htm', alt: 'First'
+  area shape: 'rect', coords: [0,0,100,100], href: 'second.htm', alt: 'Second'
+  area shape: 'rect', coords: [0,0,100,100], href: 'third.htm', alt: 'Third'
+end
+```
+
+returns
+
+```html
+<img src="matestack-logo.png" alt="otherlogo" width="500" height="300" usemap="#newmap">
+
+<map name="newmap">
+   <area shape="rect" coords="0,0,100,100" href="first.htm" alt="First">
+   <area shape="rect" coords="100,100,200,200" href="second.htm" alt="Second">
+   <area shape="rect" coords="200,200,300,300" href="third.htm" alt="Third">
+</map>
+```

--- a/docs/components/img.md
+++ b/docs/components/img.md
@@ -6,16 +6,19 @@ The HTML img tag implemented in ruby.
 
 ## Parameters
 
-The image takes a mandatory path argument and can take 3 optional configuration params.
+The image takes a mandatory path argument and can take 4 optional configuration params.
 
-#### # path
-Expects a string with the source to the image. It looks for the image in the assets/images folder and uses the standard Rails asset pipeline.
+#### # alt (optional)
+Expects a string with the alt text the image should have.
 
 #### # height (optional)
 Expects an integer with the height of the image in px.
 
+#### # path
+Expects a string with the source to the image. It looks for the image in the assets/images folder and uses the standard Rails asset pipeline.
+
+#### # usemap (optional)
+Expects a string to specify the image as a client-side image-map.
+
 #### # width (optional)
 Expects an integer with the width of the image in px.
-
-#### # alt (optional)
-Expects a string with the alt text the image should have.

--- a/docs/components/map.md
+++ b/docs/components/map.md
@@ -1,0 +1,41 @@
+# matestack core component: Map
+
+Show [specs](/spec/usage/components/map_spec.rb)
+
+The HTML `<map>` tag implemented in Ruby.
+
+## Parameters
+This component has a required `name` attribute and takes 2 optional configuration params. It contains a number of `<area>` elements that define the clickable areas in the image map.
+
+#### # id (optional)
+Expects a string with all ids the `<map>` should have.
+
+#### # class (optional)
+Expects a string with all classes the `<map>` should have.
+
+#### # name
+Specifies the name of a parameter.
+
+## Example:
+
+```ruby
+img path: 'matestack-logo.png', width: 500, height: 300, alt: "otherlogo",  usemap: "#newmap"
+
+map name: 'newmap' do
+  area shape: 'rect', coords: [0,0,100,100], href: 'first.htm', alt: 'First'
+  area shape: 'rect', coords: [0,0,100,100], href: 'second.htm', alt: 'Second'
+  area shape: 'rect', coords: [0,0,100,100], href: 'third.htm', alt: 'Third'
+end
+```
+
+returns
+
+```html
+<img src="matestack-logo.png" alt="otherlogo" width="500" height="300" usemap="#newmap">
+
+<map name="newmap">
+   <area shape="rect" coords="0,0,100,100" href="first.htm" alt="First">
+   <area shape="rect" coords="100,100,200,200" href="second.htm" alt="Second">
+   <area shape="rect" coords="200,200,300,300" href="third.htm" alt="Third">
+</map>
+```

--- a/spec/usage/components/img_spec.rb
+++ b/spec/usage/components/img_spec.rb
@@ -19,6 +19,6 @@ describe 'Img Component', type: :feature, js: true do
     visit '/example'
 
     expect(page).to have_xpath("//img[contains(@src,'matestack-logo') and @alt='logo' and @width='500' and @height='300']")
-    expect(page).to have_xpath("//img[contains(@src,'matestack-logo') and @alt='otherlogo' and @width='500' and @height='300'] and @usemap='\#newmap'")
+    expect(page).to have_xpath("//img[contains(@src,'matestack-logo') and @alt='otherlogo' and @width='500' and @height='300' and @usemap='\#newmap']")
   end
 end

--- a/spec/usage/components/img_spec.rb
+++ b/spec/usage/components/img_spec.rb
@@ -8,7 +8,10 @@ describe 'Img Component', type: :feature, js: true do
     class ExamplePage < Matestack::Ui::Page
       def response
         components {
+          # simple image
           img path: 'matestack-logo.png', width: 500, height: 300, alt: "logo"
+          # using usemap
+          img path: 'matestack-logo.png', width: 500, height: 300, alt: "otherlogo",  usemap: "#newmap"
         }
       end
     end
@@ -16,5 +19,6 @@ describe 'Img Component', type: :feature, js: true do
     visit '/example'
 
     expect(page).to have_xpath("//img[contains(@src,'matestack-logo') and @alt='logo' and @width='500' and @height='300']")
+    expect(page).to have_xpath("//img[contains(@src,'matestack-logo') and @alt='otherlogo' and @width='500' and @height='300'] and @usemap='\#newmap'")
   end
 end

--- a/spec/usage/components/map_spec.rb
+++ b/spec/usage/components/map_spec.rb
@@ -12,8 +12,8 @@ describe 'Map Component', type: :feature, js: true do
 
           map name: 'newmap' do
             area shape: 'rect', coords: [0,0,100,100], href: 'first.htm', alt: 'First'
-            area shape: 'rect', coords: [0,0,100,100], href: 'second.htm', alt: 'Second'
-            area shape: 'rect', coords: [0,0,100,100], href: 'third.htm', alt: 'Third'
+            area shape: 'rect', coords: [100,100,200,200], href: 'second.htm', alt: 'Second'
+            area shape: 'rect', coords: [200,200,300,300], href: 'third.htm', alt: 'Third'
           end
         }
       end
@@ -24,15 +24,14 @@ describe 'Map Component', type: :feature, js: true do
     static_output = page.html
 
     expected_static_output = <<~HTML
-    <img src="matestack-logo.png" alt="otherlogo" width="500" height="300" usemap="#newmap">
-
     <map name="newmap">
-       <area shape="rect" coords="0,0,100,100" href="first.htm" alt="First">
-       <area shape="rect" coords="100,100,200,200" href="second.htm" alt="Second">
-       <area shape="rect" coords="200,200,300,300" href="third.htm" alt="Third">
+       <area alt="First" coords="0,0,100,100" href="first.htm" shape="rect">
+       <area alt="Second" coords="100,100,200,200" href="second.htm" shape="rect">
+       <area alt="Third" coords="200,200,300,300" href="third.htm" shape="rect">
     </map>
     HTML
 
     expect(stripped(static_output)).to include(stripped(expected_static_output))
+    expect(page).to have_xpath("//img[contains(@src,'matestack-logo') and @alt='otherlogo' and @width='500' and @height='300' and @usemap='\#newmap']")
   end
 end

--- a/spec/usage/components/map_spec.rb
+++ b/spec/usage/components/map_spec.rb
@@ -1,0 +1,38 @@
+require_relative '../../support/utils'
+include Utils
+
+describe 'Map Component', type: :feature, js: true do
+
+  it 'Renders an image and a map containing areas on the page' do
+
+    class ExamplePage < Matestack::Ui::Page
+      def response
+        components {
+          img path: 'matestack-logo.png', width: 500, height: 300, alt: "otherlogo",  usemap: "#newmap"
+
+          map name: 'newmap' do
+            area shape: 'rect', coords: [0,0,100,100], href: 'first.htm', alt: 'First'
+            area shape: 'rect', coords: [0,0,100,100], href: 'second.htm', alt: 'Second'
+            area shape: 'rect', coords: [0,0,100,100], href: 'third.htm', alt: 'Third'
+          end
+        }
+      end
+    end
+
+    visit '/example'
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+    <img src="matestack-logo.png" alt="otherlogo" width="500" height="300" usemap="#newmap">
+
+    <map name="newmap">
+       <area shape="rect" coords="0,0,100,100" href="first.htm" alt="First">
+       <area shape="rect" coords="100,100,200,200" href="second.htm" alt="Second">
+       <area shape="rect" coords="200,200,300,300" href="third.htm" alt="Third">
+    </map>
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+end

--- a/spec/usage/components/pre_spec.rb
+++ b/spec/usage/components/pre_spec.rb
@@ -20,7 +20,7 @@ describe 'Pre Component', type: :feature, js: true do
     expected_static_output = <<~HTML
       <pre>This is preformatted text</pre>
     HTML
-    p stripped(static_output)
+
     expect(stripped(static_output)).to include(stripped(expected_static_output))
   end
 


### PR DESCRIPTION
## Issue https://github.com/basemate/matestack-ui-core/issues/197: Adds map component

### Changes

- [x] Adds the tested and documented map component
- [x] Modifies the image component to play alongside the map component
- [x] Adds the tested and documented area component (needed for map component, #161)
