### PR TITLE
remove manifest link as it is not used and throws errors

### DIFF
--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,4 +1,3 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
-//= link matestack_ui_core_manifest.js


### PR DESCRIPTION
## Issue https://github.com/basemate/matestack-ui-core/issues/277: Missing manifest file

### Changes

- [x] removed manifest link

### Notes

- the manifest file was linked when the dummy app was set up to use webpacker
- webpacker is not used currently in the dummy app
- manifest file link can be removed
