### PR TITLE
enable usage of async rerender_on on component-level

### DIFF
--- a/app/concepts/matestack/ui/core/component/dynamic.rb
+++ b/app/concepts/matestack/ui/core/component/dynamic.rb
@@ -157,7 +157,7 @@ module Matestack::Ui::Core::Component
       @nodes = Matestack::Ui::Core::ComponentNode.build(self, nil, &block)
 
       @nodes.each do |key, node|
-        @cells[key] = to_cell(key, node["component_name"], node["config"], node["argument"], node["components"], node["included_config"], node["cached_params"])
+        @cells[key] = to_cell("#{@component_key}__#{key}", node["component_name"], node["config"], node["argument"], node["components"], node["included_config"], node["cached_params"])
       end
     end
 
@@ -188,6 +188,38 @@ module Matestack::Ui::Core::Component
         end
       end
       result.join(" ")
+    end
+
+    def render_child_component component_key, current_search_keys_array
+      if respond_to? :prepare
+        prepare
+      end
+
+      response
+
+      if current_search_keys_array.count > 1
+        if @nodes.dig(*current_search_keys_array) == nil
+          rest = []
+          while @nodes.dig(*current_search_keys_array) == nil
+            rest << current_search_keys_array.pop
+          end
+          node = @nodes.dig(*current_search_keys_array)
+          cell = to_cell(component_key, node["component_name"], node["config"], node["argument"], node["components"], node["included_config"], node["cached_params"])
+          begin
+            return cell.render_child_component component_key, rest.reverse[1..-1]
+          rescue
+            return cell.render_content
+          end
+        else
+          node = @nodes.dig(*current_search_keys_array)
+          cell = to_cell(component_key, node["component_name"], node["config"], node["argument"], node["components"], node["included_config"], node["cached_params"])
+          return cell.render_content
+        end
+      else
+        node = @nodes[current_search_keys_array[0]]
+        cell = to_cell(component_key, node["component_name"], node["config"], node["argument"], node["components"], node["included_config"], node["cached_params"])
+        return cell.render_content
+      end
     end
 
     private

--- a/docs/components/async.md
+++ b/docs/components/async.md
@@ -6,8 +6,6 @@ As the name suggests, the async component allows us to let our components behave
 
 Please be aware that, if not configured otherwise, the async core component does get loaded and displayed on initial pageload!
 
-**the async component currently only works on page-level --> we're working on it in order support the usage of async within a component [#75](https://github.com/basemate/matestack-ui-core/issues/75)**
-
 ## Parameters
 
 The async core component accepts the following parameters:


### PR DESCRIPTION
## Issue https://github.com/basemate/matestack-ui-core/issues/75: async rerender on component-level

### Changes

- [x] fixed component_keys from components used in component-level
- [x] added deep component lookup on page
- [x] added deep component lookup on component (recursive, unlimited nesting)
- [x] added tests for `async` `rerender_on` usage on component-level
- [x] removed limitation note on docs and error message

