### PR TITLE
fixed form component usage on component-level

### DIFF
--- a/app/lib/matestack/ui/core/component_node.rb
+++ b/app/lib/matestack/ui/core/component_node.rb
@@ -13,10 +13,10 @@ module Matestack::Ui::Core
       @hash = {}
       @node_start_id = 0
       @component_instance = component_instance
-      @included_config = included_config
       component_instance.instance_variables.each do |component_instance_var_key|
         self.instance_variable_set(component_instance_var_key, component_instance.instance_variable_get(component_instance_var_key))
       end
+      @included_config = included_config
     end
 
     def method_missing meth, *args, &block

--- a/spec/usage/components/form_spec.rb
+++ b/spec/usage/components/form_spec.rb
@@ -1554,6 +1554,61 @@ describe "Form Component", type: :feature, js: true do
       it "can have a label"
 
     end
+
+    describe "Usage on Component Level" do
+
+      it "Example 1 - Async submit request with clientside payload from component-level" do
+
+        module Components end
+
+        class Components::SomeComponent < Matestack::Ui::StaticComponent
+
+          def response
+            components {
+              form form_config, :include do
+                form_input id: "my-test-input", key: :foo, type: :text
+                form_submit do
+                  button text: "Submit me!"
+                end
+              end
+            }
+          end
+
+          def form_config
+            return {
+              for: :my_object,
+              method: :post,
+              path: :success_form_test_path,
+              params: {
+                id: 42
+              }
+            }
+          end
+        end
+
+        class ExamplePage < Matestack::Ui::Page
+
+          def response
+            components {
+              div do
+                custom_someComponent
+              end
+            }
+          end
+
+        end
+
+        visit "/example"
+
+        fill_in "my-test-input", with: "bar"
+        click_button "Submit me!"
+
+        expect_any_instance_of(FormTestController).to receive(:expect_params)
+          .with(hash_including(my_object: { foo: "bar" }))
+
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
## Issue https://github.com/basemate/matestack-ui-core/issues/256: Form Component on Component Level

### Changes

- [x] fixed component node builder in order to properly include `included_config`
- [x] resolves bug described in issue referenced above
- [x] added tests for forms used on component-level
