### PR TITLE
add optgroup matestack core component

### DIFF
--- a/app/concepts/matestack/ui/core/optgroup/optgroup.haml
+++ b/app/concepts/matestack/ui/core/optgroup/optgroup.haml
@@ -1,0 +1,3 @@
+%optgroup{@tag_attributes}
+  - if block_given?
+    = yield

--- a/app/concepts/matestack/ui/core/optgroup/optgroup.rb
+++ b/app/concepts/matestack/ui/core/optgroup/optgroup.rb
@@ -1,0 +1,10 @@
+module Matestack::Ui::Core::Optgroup
+  class Optgroup < Matestack::Ui::Core::Component::Static
+    def setup
+      @tag_attributes.merge!(
+        disabled: options[:disabled] ||= nil,
+        label: options[:label]
+      )
+    end
+  end
+end

--- a/app/concepts/matestack/ui/core/option/option.haml
+++ b/app/concepts/matestack/ui/core/option/option.haml
@@ -1,0 +1,5 @@
+%option{@tag_attributes}
+  - if options[:text].blank? && block_given?
+    = yield
+  - else
+    = options[:text]

--- a/app/concepts/matestack/ui/core/option/option.rb
+++ b/app/concepts/matestack/ui/core/option/option.rb
@@ -1,0 +1,12 @@
+module Matestack::Ui::Core::Option
+  class Option < Matestack::Ui::Core::Component::Static
+    def setup
+      @tag_attributes.merge!(
+        disabled: options[:disabled] ||= nil,
+        selected: options[:selected] ||= nil,
+        label: options[:label],
+        value: options[:value]
+      )
+    end
+  end
+end

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -50,6 +50,7 @@ You can build your [own components](/docs/extend/README.md) as well, both static
 - [nav](/docs/components/nav.md)
 - [noscript](/docs/components/noscript.md)
 - [object](/docs/components/object.md)
+- [option](/docs/components/option.md)
 - [output](/docs/components/output.md)
 - [paragraph](/docs/components/paragraph.md)
 - [param](/docs/components/param.md)

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -50,6 +50,7 @@ You can build your [own components](/docs/extend/README.md) as well, both static
 - [nav](/docs/components/nav.md)
 - [noscript](/docs/components/noscript.md)
 - [object](/docs/components/object.md)
+- [optgroup](/docs/components/optgroup.md)
 - [option](/docs/components/option.md)
 - [output](/docs/components/output.md)
 - [paragraph](/docs/components/paragraph.md)

--- a/docs/components/optgroup.md
+++ b/docs/components/optgroup.md
@@ -1,0 +1,39 @@
+# matestack core component: Optgroup
+
+Show [specs](/spec/usage/components/optgroup_spec.rb)
+
+The HTML `<optgroup>` tag implemented in ruby.
+
+## Parameters
+
+This component can take 4 optional configuration params and yield the passed content.
+
+#### # id (optional)
+Expects a string with all ids the `<optgroup>` should have.
+
+#### # class (optional)
+Expects a string with all classes the `<optgroup>` should have.
+
+#### # disabled (optional)
+Specifies that the `<optgroup>` should be disabled.
+
+#### # label (optional)
+Specifies a label for the `<optgroup>`.
+
+## Example: Yield a given block
+
+```ruby
+optgroup label: 'Swedish Cars' do
+  option text: 'Volvo', value: 'volvo'
+  option text: 'Saab', value: 'saab'
+end
+```
+
+returns
+
+```html
+<optgroup label="Swedish Cars">
+  <option value="volvo">Volvo</option>
+  <option value="saab">Saab</option>
+</optgroup>
+```

--- a/docs/components/option.md
+++ b/docs/components/option.md
@@ -1,0 +1,83 @@
+# matestack core component: Option
+
+Show [specs](/spec/usage/components/option_spec.rb)
+
+The HTML `<option>` tag implemented in ruby.
+
+## Parameters
+
+This component can take 7 optional configuration params and either yield content or display what gets passed to the `text` configuration param.
+
+#### # id (optional)
+Expects a string with all ids the `<option>` should have.
+
+#### # class (optional)
+Expects a string with all classes the `<option>` should have.
+
+#### # disabled (optional)
+Specifies that the `<option>` should be disabled.
+
+#### # label (optional)
+Specifies a shorter label for the `<option>`.
+
+#### # text (optional)
+Specifies the text the `<option>` should contain.
+
+#### # selected (optional)
+Specifies that the `<option>` should be pre-selected when the page loads.
+
+#### # value (optional)
+Specifies the value to be sent to a server.
+
+
+## Example 1: Render `options[:text]` param
+
+```ruby
+option text: 'Option 1'
+```
+
+returns
+
+```html
+<option>Option 1</option>
+```
+
+## Example 2: Render `options[:label]` param
+
+```ruby
+option label: 'Option 2'
+```
+
+returns
+
+```html
+<option label="Option 2"></option>
+```
+
+## Example 3: Render with more attributes
+
+```ruby
+option disabled: true, label: 'Option 3', selected: true, value: '3'
+```
+
+returns
+
+```html
+<option disabled="disabled" label="Option 3" selected="selected" value="3"></option>
+```
+
+## Example 4: Yield a given block
+
+```ruby
+option id: 'foo', class: 'bar' do
+  plain 'Option 4'
+end
+```
+
+returns
+
+```html
+<option id="foo" class="bar">
+  Option 4
+</option>
+```

--- a/spec/usage/components/optgroup_spec.rb
+++ b/spec/usage/components/optgroup_spec.rb
@@ -1,0 +1,89 @@
+require_relative '../../support/utils'
+include Utils
+
+describe 'Optgroup component', type: :feature, js: true do
+  it 'Renders a optgroup tag on a page' do
+    class ExamplePage < Matestack::Ui::Page
+      def response
+        components {
+          # Just the tag
+          optgroup
+
+          # The tag with a label
+          optgroup label: 'Optgroup'
+
+          # Optgroup tag without label but sub-components
+          optgroup do
+            option text: 'Option A'
+            option text: 'Option B'
+            option text: 'Option C'
+          end
+
+          # Simple optgroup
+          optgroup label: 'Simple Group' do
+            option text: 'Option D'
+            option text: 'Option E'
+            option text: 'Option F'
+          end
+
+          # Enhanced optgroups
+          optgroup label: 'Enabled Group 1', class: 'enabled' do
+            option text: 'Option G'
+            option text: 'Option H'
+            option text: 'Option I'
+          end
+
+          optgroup label: 'Disabled Group 2', disabled: true, id: 'disabled' do
+            option text: 'Option J'
+            option text: 'Option K'
+            option text: 'Option L'
+          end
+
+          optgroup label: 'Not Disabled Group 3', disabled: false, class: 'group', id: 'not-disabled' do
+            option text: 'Option M'
+            option text: 'Option N'
+            option text: 'Option O'
+          end
+        }
+      end
+    end
+
+    visit '/example'
+
+    static_output = page.html
+
+    File.write("static.html", static_output)
+
+    expected_static_output = <<~HTML
+      <optgroup></optgroup>
+      <optgroup label="Optgroup"></optgroup>
+      <optgroup>
+        <option>Option A</option>
+        <option>Option B</option>
+        <option>Option C</option>
+      </optgroup>
+      <optgroup label="Simple Group">
+        <option>Option D</option>
+        <option>Option E</option>
+        <option>Option F</option>
+      </optgroup>
+      <optgroup label="Enabled Group 1" class="enabled">
+        <option>Option G</option>
+        <option>Option H</option>
+        <option>Option I</option>
+      </optgroup>
+      <optgroup disabled="disabled" id="disabled" label="Disabled Group 2">
+        <option>Option J</option>
+        <option>Option K</option>
+        <option>Option L</option>
+      </optgroup>
+      <optgroup id="not-disabled" label="Not Disabled Group 3" class="group">
+        <option>Option M</option>
+        <option>Option N</option>
+        <option>Option O</option>
+      </optgroup>
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+end

--- a/spec/usage/components/option_spec.rb
+++ b/spec/usage/components/option_spec.rb
@@ -1,0 +1,52 @@
+require_relative '../../support/utils'
+include Utils
+
+describe 'Option component', type: :feature, js: true do
+  it 'Renders a option tag on a page' do
+    class ExamplePage < Matestack::Ui::Page
+      def response
+        components {
+          option text: 'TEXT text'
+          option label: 'TEXT label'
+          option text: 'TEXT text', label: 'TEXT label'
+
+          option id: 'my-id', class: 'my-class' do
+            plain 'TEXT plain'
+          end
+
+          option text: 'TEXT text' do
+            plain 'TEXT plain'
+          end
+
+          option text: 'TEXT text', label: 'TEXT label' do
+            plain 'TEXT plain'
+          end
+
+          option disabled: true, label: 'TEXT label', selected: true, value: 'value'
+          option disabled: false, label: 'TEXT label', selected: true, value: 'value'
+          option disabled: true, label: 'TEXT label', selected: false, value: 'value'
+          option disabled: false, label: 'TEXT label', selected: false, value: 'value'
+        }
+      end
+    end
+
+    visit '/example'
+
+    static_output = page.html
+
+    expected_static_output = <<~HTML
+      <option>TEXT text</option>
+      <option label="TEXT label"></option>
+      <option label="TEXT label">TEXT text</option>
+      <option id="my-id" class="my-class">TEXT plain</option>
+      <option>TEXT text</option>
+      <option label="TEXT label">TEXT text</option>
+      <option disabled="disabled" label="TEXT label" selected="selected" value="value"></option>
+      <option label="TEXT label" selected="selected" value="value"></option>
+      <option disabled="disabled" label="TEXT label" value="value"></option>
+      <option label="TEXT label" value="value"></option>
+    HTML
+
+    expect(stripped(static_output)).to include(stripped(expected_static_output))
+  end
+end


### PR DESCRIPTION
Closes #202 

## Issue #202: optgroup component

Add HTML `<optgroup>` tag to core components

### Changes

 - [x] Add optgroup component
 - [x] Add specs
 - [x] Add docs

### Notes
This PR is dependent on #306  and should only be merged afterwards.