### PR TITLE
Fix RSpec spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Click here to see how you can add Matestack UI to your existing Rails applicatio
 class Pages::MyPage < Matestack::Ui::Page
 
   def prepare
-    @technologies = ["Rails", "Vue.js", "Trailblazer", "Rspec", "Capybara"]
+    @technologies = ["Rails", "Vue.js", "Trailblazer", "RSpec", "Capybara"]
   end
 
   def response


### PR DESCRIPTION
### Changes

- [x] Fixed spelling to conform with the [official one](https://github.com/rspec)

### Notes

- Nothing big ;)
