### PR TITLE
Refer to `p` for what it is (a Kernel method not a keyword)

### DIFF
--- a/docs/components/paragraph.md
+++ b/docs/components/paragraph.md
@@ -2,7 +2,7 @@
 
 Show [specs](/spec/usage/components/paragraph_spec.rb)
 
-The HTML `<p>` tag implemented in ruby. This is a workaround because the single `p` is a reserved keyword in Ruby (directly writes `obj.inspect` followed by a newline to the program’s standard output, e.g. `p foo` equals `puts foo.inspect`).
+The HTML `<p>` tag implemented in ruby. This is a workaround because the single `p` is a [`Kernel` method in Ruby](https://ruby-doc.org/core-2.6.5/Kernel.html#method-i-p) (directly writes `obj.inspect` followed by a newline to the program’s standard output, e.g. `p foo` equals `puts foo.inspect`).
 
 ## Parameters
 


### PR DESCRIPTION
For the sake of correctness :)

Side discussion: This also means that it _is_ possible to
override the p function and have it function as a paragraph
function.

Whether or not to do it is a discussion that should probably
be had in a different issue.

It's the question if taking away the beloved p from debugging
inside their component (making it available as `_p` or what not)
is a reasonable exchange for having a more direct mapping to the
HTML `<p>` tag and that people don't have to keep that one
exception mind.